### PR TITLE
limit mnemonic <= 24w; more tests against embit.bip39

### DIFF
--- a/src/krux/bip39.py
+++ b/src/krux/bip39.py
@@ -10,7 +10,7 @@ WORDINDEX = {word: i for i, word in enumerate(WORDLIST)}
 def mnemonic_to_bytes(mnemonic: str, ignore_checksum: bool = False, wordlist=WORDLIST):
     """Verifies the mnemonic checksum and returns it in bytes"""
     words = mnemonic.strip().split()
-    if len(words) % 3 != 0 or len(words) < 12:
+    if len(words) % 3 != 0 or not 12 <= len(words) <= 24:
         raise ValueError("Invalid recovery phrase")
 
     accumulator = 0

--- a/tests/test_bip39.py
+++ b/tests/test_bip39.py
@@ -2,27 +2,25 @@ from krux import bip39 as kruxbip39
 from embit import bip39
 from embit.wordlists.bip39 import WORDLIST
 import secrets
+import pytest
 
 
 def test_one_word_mnemonics():
-    for word in WORDLIST:
-        mnemonic = (word + " ") * 12
-        assert kruxbip39.mnemonic_is_valid(mnemonic) == bip39.mnemonic_is_valid(
-            mnemonic
-        )
-
-    for word in WORDLIST:
-        mnemonic = (word + " ") * 24
-        assert kruxbip39.mnemonic_is_valid(mnemonic) == bip39.mnemonic_is_valid(
-            mnemonic
-        )
+    for numwords in (12, 15, 18, 21, 24):
+        for word in WORDLIST:
+            mnemonic = (word + " ") * numwords
+            assert kruxbip39.mnemonic_is_valid(mnemonic) == bip39.mnemonic_is_valid(
+                mnemonic
+            )
 
 
 def test_edge_cases():
-    cases = [8, 16]  # 12w and 24w
+    cases = [16, 20, 24, 28, 32]  # 12w, 15w, 18w, 21w and 24w
     for case in cases:
-        ALL_ZERO_BYTES = int(0).to_bytes(16, "big")
-        ALL_ONE_BYTES = int.from_bytes(bytearray([255] * case)).to_bytes(16, "big")
+        ALL_ZERO_BYTES = int(0).to_bytes(case, "big")
+        ALL_ONE_BYTES = int.from_bytes(bytearray([255] * case), "big").to_bytes(
+            case, "big"
+        )
 
         assert (
             kruxbip39.mnemonic_to_bytes(bip39.mnemonic_from_bytes(ALL_ZERO_BYTES))
@@ -33,24 +31,45 @@ def test_edge_cases():
             == ALL_ONE_BYTES
         )
 
-        int_val = max_val = int.from_bytes(ALL_ONE_BYTES)
+        int_val = max_val = int.from_bytes(ALL_ONE_BYTES, "big")
         while int_val > 0:
             int_val = int_val // 2
-            b = int_val.to_bytes(16, "big")
+            b = int_val.to_bytes(case, "big")
             assert kruxbip39.mnemonic_to_bytes(bip39.mnemonic_from_bytes(b)) == b
 
-            b = (max_val - int_val).to_bytes(16, "big")
+            b = (max_val - int_val).to_bytes(case, "big")
             assert kruxbip39.mnemonic_to_bytes(bip39.mnemonic_from_bytes(b)) == b
 
 
 def test_random_cases():
     for _ in range(20000):
-        token12w = secrets.token_bytes(16)
-        token24w = secrets.token_bytes(32)
+        for size in (16, 20, 24, 28, 32):
+            token_bytes = secrets.token_bytes(size)
+            assert (
+                kruxbip39.mnemonic_to_bytes(bip39.mnemonic_from_bytes(token_bytes))
+                == token_bytes
+            )
 
-        assert (
-            kruxbip39.mnemonic_to_bytes(bip39.mnemonic_from_bytes(token12w)) == token12w
-        )
-        assert (
-            kruxbip39.mnemonic_to_bytes(bip39.mnemonic_from_bytes(token24w)) == token24w
-        )
+
+def test_invalid_words():
+    cases = [
+        "not all twelve of these words are in the english bip39 wordslist",
+        "not all fifteen of these words are in the english bip39 wordslist thirteen fourteen fifteen",
+        "not all eighteen of these words are in the english bip39 wordslist thirteen fourteen fifteen sixteen seventeen eighteen",
+        "not all twenty-one of these words are in the english bip39 wordslist thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twenty-one",
+        "not all twenty-four of these words are in the english bip39 wordslist thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twenty-one twenty-two twenty-three twenty-four",
+    ]
+    for case in cases:
+        with pytest.raises(ValueError, match=" is not in the dictionary"):
+            kruxbip39.mnemonic_to_bytes(case)
+
+
+def test_invalid_mnemonic_length():
+    cases = [
+        "nine is divisible by three but is not valid",
+        "thirteen is between twelve and twenty-four but it is not divisible by three",
+        "twenty-seven is divisible by three but it is not a mnemonic with valid length because bip39 support mnemonics of length twelve fifteen eighteen twenty-one and twenty-four only",
+    ]
+    for case in cases:
+        with pytest.raises(ValueError, match="Invalid recovery phrase"):
+            kruxbip39.mnemonic_to_bytes(case)


### PR DESCRIPTION
### What is this PR for?
Toward the draft pullrequest for double-mnemonics:

* krux.bip39 now limits a mnemonic to no more than 24 words (while embit allows more, which is not bip39)
* tests for krux.bip39 will test non-krux word lengths of 15, 18, 21, 24 and will test that they match embit.
* tests for krux.bip39 will cover the two ValueError legs not previously covered, explicitely looking for wrong words "not in the dictionary" and wrong lengths "Invalid recovery phrase".
* I hope I have not broken `test_edge_cases()`.  please pay attention to my changes there.


### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Other
