### PR TITLE
Fixed tests in tests/pages/home_pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ sitemap.xml.gz
 memzip-files.c
 memzip-files.zip
 .coverage
+.coverage.*
 privkey.pem
 pubkey.pem
 simulator/krux-screenshots

--- a/tests/pages/home_pages/test_bip85.py
+++ b/tests/pages/home_pages/test_bip85.py
@@ -541,7 +541,7 @@ def test_bip85_base64_password_derivation(mocker, amigo, tdata):
         assert ctx.input.wait_for_button.call_count == len(case[1])
         if case[2]:
             ctx.display.draw_hcentered_text.assert_has_calls(
-                [mocker.call(case[2], info_box=True)]
+                [mocker.call(case[2], info_box=True, highlight_prefix=':')]
             )
         if len(case) > 3 and case[3]:
             bip85_ui._base64_password_qr.assert_has_calls(

--- a/tests/pages/home_pages/test_bip85.py
+++ b/tests/pages/home_pages/test_bip85.py
@@ -541,7 +541,7 @@ def test_bip85_base64_password_derivation(mocker, amigo, tdata):
         assert ctx.input.wait_for_button.call_count == len(case[1])
         if case[2]:
             ctx.display.draw_hcentered_text.assert_has_calls(
-                [mocker.call(case[2], info_box=True, highlight_prefix=':')]
+                [mocker.call(case[2], info_box=True, highlight_prefix=":")]
             )
         if len(case) > 3 and case[3]:
             bip85_ui._base64_password_qr.assert_has_calls(

--- a/tests/pages/home_pages/test_home.py
+++ b/tests/pages/home_pages/test_home.py
@@ -810,19 +810,21 @@ def test_psbt_warnings(mocker, m5stickv, tdata):
     assert ctx.input.wait_for_button.call_count == len(btn_seq)
 
     # Multisig with wallet output descriptor not loaded had to show a warning
-    ctx.display.draw_centered_text.assert_has_calls([
-        mocker.call(                                           
-            "Warning: Wallet output descriptor not found.\n\nSome checks cannot be performed.",
-            highlight_prefix=":"
-        )
-    ])
+    ctx.display.draw_centered_text.assert_has_calls(
+        [
+            mocker.call(
+                "Warning: Wallet output descriptor not found.\n\nSome checks cannot be performed.",
+                highlight_prefix=":",
+            )
+        ]
+    )
 
     # These two calls must have occured in sequence
     ctx.display.draw_centered_text.assert_has_calls(
         [
             mocker.call(
                 "Warning: Path mismatch\nWallet: m/48h/0h/0h/2h\nPSBT: m/48h/1h/0h/2h",
-                highlight_prefix=":"
+                highlight_prefix=":",
             ),
             mocker.call(
                 "PSBT policy:\np2wsh\n2 of 3\n"
@@ -932,19 +934,21 @@ def test_psbt_warnings_taproot_miniscript(mocker, m5stickv, psbt_tdata):
 
     # Wallet output descriptor not loaded had to show a warning
     print(ctx.display.draw_centered_text.mock_calls)
-    ctx.display.draw_centered_text.assert_has_calls([
-        mocker.call(
-            "Warning: Wallet output descriptor not found.\n\nSome checks cannot be performed.",
-            highlight_prefix=':'
-        )
-    ])
+    ctx.display.draw_centered_text.assert_has_calls(
+        [
+            mocker.call(
+                "Warning: Wallet output descriptor not found.\n\nSome checks cannot be performed.",
+                highlight_prefix=":",
+            )
+        ]
+    )
 
     # These two calls must have occured in sequence
     ctx.display.draw_centered_text.assert_has_calls(
         [
             mocker.call(
                 "Warning: Path mismatch\nWallet: m/48h/0h/0h/2h\nPSBT: m/48h/1h/0h/2h",
-                highlight_prefix=":"
+                highlight_prefix=":",
             ),
             mocker.call(
                 "PSBT policy:\np2tr"
@@ -1176,12 +1180,11 @@ def test_sign_high_fee(mocker, m5stickv, tdata):
         [
             mocker.call(
                 "Warning: Path mismatch\nWallet: m/84h/0h/0h\nPSBT: m/84h/1h/0h",
-                highlight_prefix=":"
+                highlight_prefix=":",
             ),
             mocker.call("Processing.."),
             mocker.call(
-                "Warning: High fees!\n799.7% of the amount.",
-                highlight_prefix=":"
+                "Warning: High fees!\n799.7% of the amount.", highlight_prefix=":"
             ),
         ]
     )
@@ -1230,10 +1233,12 @@ def test_sign_self(mocker, m5stickv, tdata):
         [
             mocker.call(
                 "Warning: Path mismatch\nWallet: m/84h/0h/0h\nPSBT: m/84h/1h/0h",
-                highlight_prefix=":"
+                highlight_prefix=":",
             ),
             mocker.call("Processing.."),
-            mocker.call("Warning: High fees!\n799.7% of the amount.", highlight_prefix=":"),
+            mocker.call(
+                "Warning: High fees!\n799.7% of the amount.", highlight_prefix=":"
+            ),
         ]
     )
 
@@ -1282,9 +1287,11 @@ def test_sign_spent_and_self(mocker, m5stickv, tdata):
         [
             mocker.call(
                 "Warning: Path mismatch\nWallet: m/84h/0h/0h\nPSBT: m/84h/1h/0h",
-                highlight_prefix=':'
+                highlight_prefix=":",
             ),
             mocker.call("Processing.."),
-            mocker.call("Warning: High fees!\n235.9% of the amount.", highlight_prefix=':'),
+            mocker.call(
+                "Warning: High fees!\n235.9% of the amount.", highlight_prefix=":"
+            ),
         ]
     )

--- a/tests/pages/home_pages/test_home.py
+++ b/tests/pages/home_pages/test_home.py
@@ -810,15 +810,19 @@ def test_psbt_warnings(mocker, m5stickv, tdata):
     assert ctx.input.wait_for_button.call_count == len(btn_seq)
 
     # Multisig with wallet output descriptor not loaded had to show a warning
-    ctx.display.draw_centered_text.assert_any_call(
-        "Warning:\nWallet output descriptor not found.\n\nSome checks cannot be performed."
-    )
+    ctx.display.draw_centered_text.assert_has_calls([
+        mocker.call(                                           
+            "Warning: Wallet output descriptor not found.\n\nSome checks cannot be performed.",
+            highlight_prefix=":"
+        )
+    ])
 
     # These two calls must have occured in sequence
     ctx.display.draw_centered_text.assert_has_calls(
         [
             mocker.call(
-                "Warning: Path mismatch\nWallet: m/48h/0h/0h/2h\nPSBT: m/48h/1h/0h/2h"
+                "Warning: Path mismatch\nWallet: m/48h/0h/0h/2h\nPSBT: m/48h/1h/0h/2h",
+                highlight_prefix=":"
             ),
             mocker.call(
                 "PSBT policy:\np2wsh\n2 of 3\n"
@@ -927,15 +931,20 @@ def test_psbt_warnings_taproot_miniscript(mocker, m5stickv, psbt_tdata):
     assert ctx.input.wait_for_button.call_count == len(btn_seq)
 
     # Wallet output descriptor not loaded had to show a warning
-    ctx.display.draw_centered_text.assert_any_call(
-        "Warning:\nWallet output descriptor not found.\n\nSome checks cannot be performed."
-    )
+    print(ctx.display.draw_centered_text.mock_calls)
+    ctx.display.draw_centered_text.assert_has_calls([
+        mocker.call(
+            "Warning: Wallet output descriptor not found.\n\nSome checks cannot be performed.",
+            highlight_prefix=':'
+        )
+    ])
 
     # These two calls must have occured in sequence
     ctx.display.draw_centered_text.assert_has_calls(
         [
             mocker.call(
-                "Warning: Path mismatch\nWallet: m/48h/0h/0h/2h\nPSBT: m/48h/1h/0h/2h"
+                "Warning: Path mismatch\nWallet: m/48h/0h/0h/2h\nPSBT: m/48h/1h/0h/2h",
+                highlight_prefix=":"
             ),
             mocker.call(
                 "PSBT policy:\np2tr"
@@ -1166,10 +1175,14 @@ def test_sign_high_fee(mocker, m5stickv, tdata):
     ctx.display.draw_centered_text.assert_has_calls(
         [
             mocker.call(
-                "Warning: Path mismatch\nWallet: m/84h/0h/0h\nPSBT: m/84h/1h/0h"
+                "Warning: Path mismatch\nWallet: m/84h/0h/0h\nPSBT: m/84h/1h/0h",
+                highlight_prefix=":"
             ),
             mocker.call("Processing.."),
-            mocker.call("Warning: High fees!\n799.7% of the amount."),
+            mocker.call(
+                "Warning: High fees!\n799.7% of the amount.",
+                highlight_prefix=":"
+            ),
         ]
     )
 
@@ -1216,10 +1229,11 @@ def test_sign_self(mocker, m5stickv, tdata):
     ctx.display.draw_centered_text.assert_has_calls(
         [
             mocker.call(
-                "Warning: Path mismatch\nWallet: m/84h/0h/0h\nPSBT: m/84h/1h/0h"
+                "Warning: Path mismatch\nWallet: m/84h/0h/0h\nPSBT: m/84h/1h/0h",
+                highlight_prefix=":"
             ),
             mocker.call("Processing.."),
-            mocker.call("Warning: High fees!\n799.7% of the amount."),
+            mocker.call("Warning: High fees!\n799.7% of the amount.", highlight_prefix=":"),
         ]
     )
 
@@ -1267,9 +1281,10 @@ def test_sign_spent_and_self(mocker, m5stickv, tdata):
     ctx.display.draw_centered_text.assert_has_calls(
         [
             mocker.call(
-                "Warning: Path mismatch\nWallet: m/84h/0h/0h\nPSBT: m/84h/1h/0h"
+                "Warning: Path mismatch\nWallet: m/84h/0h/0h\nPSBT: m/84h/1h/0h",
+                highlight_prefix=':'
             ),
             mocker.call("Processing.."),
-            mocker.call("Warning: High fees!\n235.9% of the amount."),
+            mocker.call("Warning: High fees!\n235.9% of the amount.", highlight_prefix=':'),
         ]
     )

--- a/tests/pages/home_pages/test_sign_message_ui.py
+++ b/tests/pages/home_pages/test_sign_message_ui.py
@@ -216,7 +216,7 @@ def test_sign_message(mocker, m5stickv, tdata):
             home.display_qr_codes.assert_has_calls(
                 [
                     mocker.call(case[4], case[1], "Signed Message"),
-                    mocker.call(case[5], case[1], "Hex Public Key"),
+                    mocker.call(case[5], case[1], "Hex Public Key:"),
                 ]
             )
         else:

--- a/tests/pages/test_capture_entropy.py
+++ b/tests/pages/test_capture_entropy.py
@@ -195,7 +195,8 @@ def test_poor_variance(amigo, mocker):
 
     # Assert ctx.display.draw_centered_text was called with "Insufficient entropy!"
     call_message = mocker.call(
-        ENTROPY_MESSAGE_STR % (shannon_value, total_shannon, variance)
+        ENTROPY_MESSAGE_STR % (shannon_value, total_shannon, variance),
+        highlight_prefix=":"
     )
 
     ctx.display.draw_centered_text.assert_has_calls([call_message])
@@ -252,7 +253,8 @@ def test_good_variance_good_shannons_entropy(amigo, mocker):
 
     # Assert ctx.display.draw_centered_text was called with "Insufficient entropy!"
     call_message = mocker.call(
-        ENTROPY_MESSAGE_STR % (shannon_value, total_shannon, variance)
+        ENTROPY_MESSAGE_STR % (shannon_value, total_shannon, variance),
+        highlight_prefix=":"
     )
 
     ctx.display.draw_centered_text.assert_has_calls([call_message])

--- a/tests/pages/test_capture_entropy.py
+++ b/tests/pages/test_capture_entropy.py
@@ -196,7 +196,7 @@ def test_poor_variance(amigo, mocker):
     # Assert ctx.display.draw_centered_text was called with "Insufficient entropy!"
     call_message = mocker.call(
         ENTROPY_MESSAGE_STR % (shannon_value, total_shannon, variance),
-        highlight_prefix=":"
+        highlight_prefix=":",
     )
 
     ctx.display.draw_centered_text.assert_has_calls([call_message])
@@ -254,7 +254,7 @@ def test_good_variance_good_shannons_entropy(amigo, mocker):
     # Assert ctx.display.draw_centered_text was called with "Insufficient entropy!"
     call_message = mocker.call(
         ENTROPY_MESSAGE_STR % (shannon_value, total_shannon, variance),
-        highlight_prefix=":"
+        highlight_prefix=":",
     )
 
     ctx.display.draw_centered_text.assert_has_calls([call_message])

--- a/tests/pages/test_encryption_ui.py
+++ b/tests/pages/test_encryption_ui.py
@@ -143,7 +143,12 @@ def test_encrypt_cbc_sd_ui(m5stickv, mocker, mock_file_operations):
     storage_ui.encrypt_menu()
 
     ctx.display.draw_centered_text.assert_has_calls(
-        [mocker.call("Encrypted mnemonic stored with ID: " + ENCRYPTED_QR_TITLE_CBC, highlight_prefix=':')],
+        [
+            mocker.call(
+                "Encrypted mnemonic stored with ID: " + ENCRYPTED_QR_TITLE_CBC,
+                highlight_prefix=":",
+            )
+        ],
         any_order=True,
     )
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)

--- a/tests/pages/test_encryption_ui.py
+++ b/tests/pages/test_encryption_ui.py
@@ -124,11 +124,12 @@ def test_encrypt_cbc_sd_ui(m5stickv, mocker, mock_file_operations):
         [BUTTON_PAGE]  # Move to store on SD card
         + [BUTTON_ENTER]  # Confirm SD card
         + [BUTTON_ENTER]  # Confirm add CBC cam entropy
-        + [BUTTON_PAGE]  # add custom ID - move to no
+        + [BUTTON_ENTER]  # add custom ID - move to no
         + [BUTTON_ENTER]  # Confirm encryption ID
     )
     ctx = create_ctx(mocker, BTN_SEQUENCE)
     ctx.wallet = Wallet(Key(CBC_WORDS, TYPE_SINGLESIG, NETWORKS["main"]))
+
     storage_ui = EncryptMnemonic(ctx)
     mocker.patch(
         "krux.pages.encryption_ui.EncryptionKey.encryption_key",
@@ -142,7 +143,7 @@ def test_encrypt_cbc_sd_ui(m5stickv, mocker, mock_file_operations):
     storage_ui.encrypt_menu()
 
     ctx.display.draw_centered_text.assert_has_calls(
-        [mocker.call("Encrypted mnemonic stored with ID: " + ENCRYPTED_QR_TITLE_CBC)],
+        [mocker.call("Encrypted mnemonic stored with ID: " + ENCRYPTED_QR_TITLE_CBC, highlight_prefix=':')],
         any_order=True,
     )
     assert ctx.input.wait_for_button.call_count == len(BTN_SEQUENCE)
@@ -156,7 +157,7 @@ def test_encrypt_save_error_exist(m5stickv, mocker, mock_file_operations):
     from krux.key import Key
     from embit.networks import NETWORKS
 
-    BTN_SEQUENCE = [BUTTON_ENTER] + [BUTTON_PAGE]  # Confirm flash store  # Cancel
+    BTN_SEQUENCE = [BUTTON_ENTER] + [BUTTON_ENTER]  # Confirm flash store  # Cancel
     ctx = create_ctx(mocker, BTN_SEQUENCE)
     ctx.wallet = Wallet(Key(ECB_WORDS, False, NETWORKS["main"]))
     storage_ui = EncryptMnemonic(ctx)
@@ -190,7 +191,7 @@ def test_encrypt_save_error(m5stickv, mocker, mock_file_operations):
 
     BTN_SEQUENCE = (
         [BUTTON_ENTER]  # Confirm flash store
-        + [BUTTON_PAGE]  # add custom ID - move to no
+        + [BUTTON_ENTER]  # add custom ID - move to no
         + [BUTTON_ENTER]  # Confirm encryption ID
     )
     ctx = create_ctx(mocker, BTN_SEQUENCE)
@@ -225,7 +226,7 @@ def test_encrypt_to_qrcode_ecb_ui(m5stickv, mocker):
         [BUTTON_PAGE] * 2  # Move to store on Encrypted QR
         + [BUTTON_ENTER]  # Confirm Encrypted QR
         # Key is mocked here, no press needed
-        + [BUTTON_PAGE]  # add custom ID - No
+        + [BUTTON_ENTER]  # add custom ID - No
         # QR view is mocked here, no press needed
     )
     ctx = create_ctx(mocker, BTN_SEQUENCE)
@@ -262,7 +263,7 @@ def test_encrypt_to_qrcode_cbc_ui(m5stickv, mocker):
         + [BUTTON_ENTER]  # Confirm Encrypted QR
         + [BUTTON_ENTER]  # Confirm to add CBC cam entropy
         # Key is mocked here, no press needed
-        + [BUTTON_PAGE]  # add custom ID - No
+        + [BUTTON_ENTER]  # add custom ID - No
         # QR view is mocked here, no press needed
     )
     ctx = create_ctx(mocker, BTN_SEQUENCE)

--- a/tests/pages/test_page.py
+++ b/tests/pages/test_page.py
@@ -46,12 +46,16 @@ def test_flash_text(mocker, m5stickv, mock_page_cls):
 
     page.flash_text("Hello world", duration=1000)
 
-    ctx.display.flash_text.assert_called_with("Hello world", WHITE, 1000, highlight_prefix="")
+    ctx.display.flash_text.assert_called_with(
+        "Hello world", WHITE, 1000, highlight_prefix=""
+    )
 
     page.flash_error("Error")
 
     assert ctx.display.flash_text.call_count == 2
-    ctx.display.flash_text.assert_called_with("Error", RED, FLASH_MSG_TIME, highlight_prefix="")
+    ctx.display.flash_text.assert_called_with(
+        "Error", RED, FLASH_MSG_TIME, highlight_prefix=""
+    )
 
 
 def test_prompt_m5stickv(mocker, m5stickv, mock_page_cls):

--- a/tests/pages/test_page.py
+++ b/tests/pages/test_page.py
@@ -46,12 +46,12 @@ def test_flash_text(mocker, m5stickv, mock_page_cls):
 
     page.flash_text("Hello world", duration=1000)
 
-    ctx.display.flash_text.assert_called_with("Hello world", WHITE, 1000)
+    ctx.display.flash_text.assert_called_with("Hello world", WHITE, 1000, highlight_prefix="")
 
     page.flash_error("Error")
 
     assert ctx.display.flash_text.call_count == 2
-    ctx.display.flash_text.assert_called_with("Error", RED, FLASH_MSG_TIME)
+    ctx.display.flash_text.assert_called_with("Error", RED, FLASH_MSG_TIME, highlight_prefix="")
 
 
 def test_prompt_m5stickv(mocker, m5stickv, mock_page_cls):

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -701,7 +701,7 @@ def test_flash_text(mocker, m5stickv):
     d.flash_text("test", WHITE)
 
     d.clear.assert_called()
-    d.draw_centered_text.assert_called_with("test", WHITE)
+    d.draw_centered_text.assert_called_with("test", WHITE, highlight_prefix="")
     time.sleep_ms.assert_called_with(FLASH_MSG_TIME)
 
 


### PR DESCRIPTION
Fix tests on https://github.com/selfcustody/krux/pull/521

### What is this PR for?

This PR fix tests in tests/pages/home_pages by adding highlight_prefix argument in mock's assert_has_calls in:

* test_bip85.py: test_bip85_bas64_password_derivation

* test_home.py: test_sign_self, test_sign_high_fee, test_psbt_warnings,
test_psbt_warnings_taproot_miniscript

### What is the purpose of this pull request?
- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Other: tests
